### PR TITLE
feat: options for custom key transformation and glue empty string

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,8 @@ This module recursively squashes an Object/Array. The output is a flat object â€
 
 By default, the `.` character is used to glue/join layers' keys together. This is customizable.
 
+Every flatten key can be customized allowing any type of transformation.
+
 Finally, by default, any keys with nullish values (`null` and `undefined`) are **not** included in the return object.
 
 ## Install
@@ -60,7 +62,7 @@ flattie({
 
 ## API
 
-### flattie(input, glue?, keepNullish?)
+### flattie(input, glue?, keepNullish?, options?)
 Returns: `Object`
 
 Returns a new object with a single level of depth.
@@ -112,6 +114,80 @@ flattie({ foo }, '.', true);
 //=>   'foo.5': 'world'
 //=> }
 ```
+
+#### options
+Type: `Object`<br>
+Default: `{}`
+
+An object containing additional options for handlings/transformation applied during the flatting of the input.
+
+
+##### options.transformKey
+Type: `Function (pfx: string, key: string) => string`<br>
+Default: `undefined`
+
+Must be a function getting in input actual `pfx` and `key` which is flatting and returning a `string`.
+
+```js
+// Example flatting an object using snake case transformation.
+
+const foo = { aaa: { bbb: { ccc: 1 }}, bbb: 2, ccc, ddd: 4 };
+
+flattie(foo, '_', true, {
+  transformKey: (pfx, key) => key.toLowerCase()
+});
+//=> {
+//=>   'aaa_bbb_ccc': 1,
+//=>   'ccc_foo': 'bar',
+//=>   'ccc_baz': 'bat',
+//=>   'ddd': 4,
+//=>   'bbb': 2,
+//=> }
+
+// Example flatting an object using camel case transformation.
+
+const foo = { aaa: { bbb: { ccc: 1 }}, bbb: 2, ccc, ddd: 4 };
+
+flattie(foo, '.', true, {
+  transformKey: (pfx, key) => {
+					if(!pfx) { return key.toLowerCase() }
+					if (key.length == 1) { return key.toUpperCase() }
+					return key.slice(0, 1).toUpperCase() + key.slice(1, key.length).toLowerCase()
+			},
+});
+//=> {
+//=>   'aaa.Bbb.Ccc': 1,
+//=>   'ccc.Foo': 'bar',
+//=>   'ccc.Baz': 'bat',
+//=>   'ddd': 4,
+//=>   'bbb': 2,
+//=> }
+```
+
+
+##### options.allowGlueEmptyString
+Type: `Boolean`<br>
+Default: `false`
+
+Can be used to allow the `""` value as glue.
+
+```js
+// Example flatting an object using snake case transformation.
+
+const foo = { aaa: { bbb: { ccc: 1 }}, bbb: 2, ccc, ddd: 4 };
+
+flattie(foo, '', true, {
+  allowGlueEmptyString: true
+});
+//=> {
+//=>   'aaabbbccc': 1,
+//=>   'cccfoo': 'bar',
+//=>   'cccbaz': 'bat',
+//=>   'ddd': 4,
+//=>   'bbb': 2,
+//=> }
+```
+
 
 ## Benchmarks
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This module recursively squashes an Object/Array. The output is a flat object â€
 
 By default, the `.` character is used to glue/join layers' keys together. This is customizable.
 
-Every flatten key can be customized allowing any type of transformation.
+Every flatten key can be customized using a custom transformer function.
 
 Finally, by default, any keys with nullish values (`null` and `undefined`) are **not** included in the return object.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,14 @@
+/**
+ * Recursively iterates over a value (object or array) and flattens it into an output object.
+ *
+ * @param {Object} output - The object to which the flattened key-value pairs will be added.
+ * @param {*} val - The current value to process; could be a primitive, object, or array.
+ * @param {Object} options - Options for the iteration process.
+ * @param {boolean} options.nullish - Whether to include nullish values (null, undefined) in the output.
+ * @param {string} options.sep - The separator string used to concatenate nested keys.
+ * @param {string} options.key - The current key being processed, used to build the flattened key.
+ * @param {function} [options.transformKey] - An optional function to transform keys during processing.
+ */
 function iter(output, val, options) {
 
 	const {
@@ -23,6 +34,25 @@ function iter(output, val, options) {
 		}
 	}
 }
+
+/**
+ * Recursively iterate over an object or array and flatten it into a new
+ * object.
+ *
+ * @param {Object} input - The value to flatten.
+ * @param {string} [glue='.'] - The glue to use for joining nested keys. Can be
+ *     an empty string if {@link options.allowGlueEmptyString} is true.
+ * @param {boolean} [toNull=false] - Whether to include nullish values in the
+ *     output.
+ * @param {Object} [options] - Options for the iteration.
+ * @param {boolean} [options.allowGlueEmptyString=false] - Allow an empty glue
+ *     string.
+ * @param {function} [options.transformKey] - A function to call on each key.
+ *     The function should get pfx and key as inputs and return a new string. If not provided, the key will
+ *     not be transformed.
+ *
+ * @returns {Object} - The flattened object.
+ */
 export function flattie(input, glue, toNull, options = {}) {
 	var output = {};
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,12 @@
-function iter(output, nullish, sep, val, key) {
+function iter(output, val, options) {
+
+	const {
+		nullish,
+		sep,
+		key,
+		transformKey,
+	} = options || {};
+
 	var k, pfx = key ? (key + sep) : key;
 
 	if (val == null) {
@@ -6,20 +14,30 @@ function iter(output, nullish, sep, val, key) {
 	} else if (typeof val != 'object') {
 		output[key] = val;
 	} else if (Array.isArray(val)) {
-		for (k=0; k < val.length; k++) {
-			iter(output, nullish, sep, val[k], pfx + k);
+		for (k = 0; k < val.length; k++) {
+			iter(output, val[k], { nullish, sep, key: pfx + k, transformKey });
 		}
 	} else {
 		for (k in val) {
-			iter(output, nullish, sep, val[k], pfx + k);
+			iter(output, val[k], { nullish, sep, key: pfx + (transformKey ? transformKey(pfx, k) : k), transformKey });
 		}
 	}
 }
-
-export function flattie(input, glue, toNull) {
+export function flattie(input, glue, toNull, options = {}) {
 	var output = {};
+
+	if (options && options.transformKey && typeof options.transformKey !== 'function') {
+		throw new Error('value of options.transformKey must be a function returning a string');
+	}
+
 	if (typeof input == 'object') {
-		iter(output, !!toNull, glue || '.', input, '');
+		iter(output, input, {
+			nullish: !!toNull,
+			sep: (glue || ( glue == "" && options.allowGlueEmptyString )) ? glue : '.',
+			key: '',
+			transformKey: options.transformKey,
+		});
 	}
 	return output;
 }
+


### PR DESCRIPTION
Hello,

i was using Flattie because is very lightweight and works perfectly, but it was missing some features which were needed in my use case. So i decided to make this PR, hoping if someone else could be happy.

I've added a new parameter `options` in `flattie` function, which is supposed to contains these new options, but maybe others in the future. 

New options:
- `transformKey`: is a function getting in input `pfx` and `key` of the current key the function iter is processing. It's useful when you have to make transformation like camel case, uppercase, lowercase ecc...plus i decided to expose the actual prefix too in order to know if i'm processing root fields or not, but probably could be useful for something else too.
- `allowGlueEmptyString`: a boolean value which allows the empty string value on glue parameter. I decided to add a custom option to force this and not change the actual `glue || '.'` behaviour in order to not make a breaking change. This is really useful when you have to flat without adding anything to original strings.

I've run the bench on my MacBookPro M1 using node v20.10.0:

Load Time:
  flat: 0.258ms
  flatten-object: 0.375ms
  flat-obj: 0.129ms
  flattie: 0.35ms

Benchmark:
  flat               x 979,270 ops/sec ±0.36% (95 runs sampled)
  flatten-object     x 458,339 ops/sec ±0.23% (99 runs sampled)
  flat-obj           x 722,398 ops/sec ±1.40% (94 runs sampled)
  flattie            x 1,337,977 ops/sec ±0.70% (91 runs sampled)

But i don't know how you handle the update of those data in readme.md, so i didn't add for now, in case let me know how you want to go.

Thanks!
